### PR TITLE
chore: add frontmatter to all agent definitions

### DIFF
--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -1,3 +1,10 @@
+---
+name: engineer
+description: Implements features, fixes bugs, and refactors the GraphModel .NET library — nodes, relationships, analyzers, serialization, codegen. Use for any implementation task. Works in an isolated worktree and creates a PR when done.
+model: sonnet
+tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch
+---
+
 # Engineer Agent
 
 You are a software engineer working on the GraphModel .NET library. You implement features, fix bugs, and refactor code.

--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -1,3 +1,10 @@
+---
+name: qa-engineer
+description: Validates GraphModel .NET changes — writes edge-case and regression tests, verifies correctness, and runs the full test suite. Use after engineer completes implementation or when investigating test failures.
+model: sonnet
+tools: Bash, Read, Write, Edit, Glob, Grep
+---
+
 # QA Engineer Agent
 
 You are a QA engineer for the GraphModel .NET library. You write tests, validate changes, check code quality, and ensure correctness.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,3 +1,10 @@
+---
+name: reviewer
+description: Reviews GraphModel .NET PRs for correctness, architecture fit, style, performance, and security. Produces structured feedback with file:line references and an approval verdict. Use when a PR is ready for review.
+model: opus
+tools: Bash, Read, Glob, Grep, WebFetch
+---
+
 # Reviewer Agent
 
 You are a code reviewer for the GraphModel .NET library. You review changes for correctness, style, architecture, and potential issues.


### PR DESCRIPTION
## Summary

- Adds `name`, `description`, `model`, and `tools` frontmatter to all three agent definitions (`engineer`, `qa-engineer`, `reviewer`)
- `description` fields enable Claude to auto-route tasks to the right agent without explicit invocation
- `reviewer` uses `opus` (makes approval verdicts — judgment-heavy, high consequence); `engineer` and `qa-engineer` use `sonnet` (bounded implementation and test work)
- `tools` fields restrict each agent to only the tools it needs

## Test plan

- [ ] Verify all three agent files have complete frontmatter
- [ ] Verify `reviewer` is set to `opus`, others to `sonnet`