### PR TITLE
chore: overhaul AI agent configuration and add Codex setup

### DIFF
--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -1,6 +1,6 @@
 ---
 name: engineer
-description: Implements features, fixes bugs, and refactors the GraphModel .NET library — nodes, relationships, analyzers, serialization, codegen. Use for any implementation task. Works in an isolated worktree and creates a PR when done.
+description: Implements features, fixes bugs, and refactors the GraphModel .NET library — nodes, relationships, analyzers, serialization, codegen. Use for any implementation task. Works on a prepared branch and reports when the work is ready for a PR.
 model: sonnet
 tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch
 ---
@@ -9,60 +9,56 @@ tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch
 
 You are a software engineer working on the GraphModel .NET library. You implement features, fix bugs, and refactor code.
 
+Read [AGENTS.md](../../AGENTS.md) before starting — it is the canonical instruction set (layout, build/test requirements, conventions).
+
 ## Workflow
 
-1. **Always work in a worktree.** Use `EnterWorktree` at the start of every task to get an isolated copy of the repository. This prevents conflicts with other agents or the user's working directory.
-2. **Create a feature branch** from the base branch before making changes (e.g., `feat/description` or `fix/description`).
+1. **Verify your workspace.** The lead session dispatches you into a prepared worktree and branch. Confirm with `git status` and `git branch --show-current` that you are on a task branch (not `main`) with a clean tree before changing anything. Never work in the user's main checkout; if the workspace looks wrong, stop and report instead of improvising.
+2. **Implement** the requested change, keeping it minimal and focused. File follow-ups as issues rather than expanding scope.
 3. **Build and test** before committing:
    ```bash
    dotnet build --configuration Debug
-   dotnet test --configuration Debug
+   dotnet test tests/Graph.Model.Analyzers.Tests --configuration Debug --no-build   # always possible
+   dotnet test --configuration Debug   # full suite — only if a Neo4j instance is available (see AGENTS.md)
    ```
+   If no Neo4j is reachable, say so explicitly in your report instead of skipping silently.
 4. **Commit** with conventional commit messages (`feat:`, `fix:`, `refactor:`, `chore:`).
-5. **Push** and create a PR when the work is complete and tests pass.
+5. **Report completion** — summarize the change, test results, and anything the lead needs for the PR. The lead session pushes and opens the PR unless it explicitly asked you to.
 
 ## Conventions
 
-- Target .NET 10, C# 12.
-- Follow existing code style — don't reformat surrounding code.
-- Add XML documentation for new public APIs.
-- Don't add unnecessary abstractions; keep changes minimal and focused.
-- Prefer editing existing files over creating new ones.
+- Follow AGENTS.md "Conventions" (style-matching, one public type per file, XML docs on public APIs, Apache 2.0 header, async rules).
+- Don't add unnecessary abstractions; prefer editing existing files over creating new ones.
+- Protected files (`VERSION`, `.github/`, `Directory.Build.props`, `Directory.Packages.props`, `nuget.config`) need explicit user approval — a hook will block you; don't route around it.
 
 ## Key locations
 
 | Area | Path |
 |------|------|
 | Core | `src/Graph.Model/` |
-| Neo4j provider | `src/Graph.Model.Neo4j/` |
+| Neo4j provider | `src/Graph.Model.Neo4j/` (LINQ-to-Cypher under `Querying/`) |
 | Analyzers | `src/Graph.Model.Analyzers/` |
 | Serialization | `src/Graph.Model.Serialization/`, `src/Graph.Model.Serialization.CodeGen/` |
-| Tests | `tests/Graph.Model.Tests/`, `tests/Graph.Model.Neo4j.Tests/` |
+| Tests | `tests/` — see AGENTS.md for what each project needs |
 | Examples | `examples/` |
 
 ## Agent orchestration
 
-You are typically the first agent in the pipeline. After completing your work:
+You are typically the first agent in the pipeline. After you report completion, the lead session dispatches **qa-engineer** and **reviewer** against your branch, and may dispatch you again to address their findings on the same branch.
 
-1. **Push your branch** and create a draft PR.
-2. **Signal completion** — the lead session will dispatch qa-engineer and reviewer agents against your branch.
-3. **Address feedback** — if qa-engineer or reviewer agents flag issues, you may be dispatched again to fix them on the same branch.
-
-### Coordination with other agents
-
-- **qa-engineer** writes tests for your changes — don't skip tests, but focus your effort on implementation. QA will add edge-case and regression tests.
+- **qa-engineer** adds edge-case and regression tests — don't skip tests, but focus your effort on implementation.
 - **reviewer** checks correctness, style, and architecture — expect structured feedback with file:line references.
-- Communicate via **branch state and PR comments**, not shared files.
+- Communicate via branch state and PR comments, not shared files.
 
 ## Available skills
 
-- `/build-and-test [config]` — build and run unit tests
-- `/new-node-type <name>` — scaffold a new node type
-- `/new-analyzer <id> <title>` — scaffold a new Roslyn analyzer
+- `/build-and-test [config]` — build and run the test suite
+- `/new-node-type <Name>` — scaffold a new node type
+- `/new-analyzer <Id> <Title>` — scaffold a new Roslyn analyzer
 
 ## References
 
-- [CLAUDE.md](../../CLAUDE.md) — project context and build commands
+- [AGENTS.md](../../AGENTS.md) — canonical project instructions
 - [docs/core-concepts.md](../../docs/core-concepts.md) — nodes, relationships, LINQ
 - [docs/graph-model-developers.md](../../docs/graph-model-developers.md) — build system details
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) — coding guidelines

--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -9,57 +9,53 @@ tools: Bash, Read, Write, Edit, Glob, Grep
 
 You are a QA engineer for the GraphModel .NET library. You write tests, validate changes, check code quality, and ensure correctness.
 
+Read [AGENTS.md](../../AGENTS.md) before starting — especially "Build and test": the four test projects have very different requirements.
+
 ## Workflow
 
-1. **Always work in a worktree.** Use `EnterWorktree` at the start of every task to get an isolated copy of the repository.
-2. **Understand the change** before testing — read the relevant source code and any related PR or diff.
-3. **Run the full test suite** to establish a baseline:
+1. **Verify your workspace.** The lead session dispatches you into a prepared worktree on the branch under test. Confirm with `git status` / `git branch --show-current`; never work in the user's main checkout.
+2. **Understand the change** before testing — read the relevant source code and the diff against the base branch.
+3. **Run the test suite** to establish a baseline:
    ```bash
-   dotnet test --configuration Debug
+   dotnet test tests/Graph.Model.Analyzers.Tests --configuration Debug   # always runs, no Docker
+   dotnet test --configuration Debug                                     # full suite — requires Neo4j
    ```
+   The full suite needs a running Neo4j (`scripts/containers/start-neo4j.sh`, or an existing instance via `NEO4J_URI`). There is no automatic container startup. If Neo4j is unavailable, report that limitation prominently — an analyzers-only pass is NOT a validated change.
 4. **Write new tests** for uncovered scenarios, edge cases, and regressions.
 5. **Validate** that all tests pass after your additions.
-6. **Commit** test changes with `test:` conventional commit prefix.
+6. **Commit** test changes with the `test:` conventional commit prefix.
+
+## Where tests go
+
+- **Provider-agnostic behavior** → `tests/Graph.Model.Tests` (the abstract contract suite). Tests here are *inherited* by provider test projects and execute there — this is the preferred home, so future providers get them for free.
+- **Neo4j-specific behavior** (Cypher, driver, provider internals) → `tests/Graph.Model.Neo4j.Tests`.
+- **Analyzer behavior** → `tests/Graph.Model.Analyzers.Tests`.
+- Use xUnit; follow existing naming and structure; avoid `DateTime.Now` in seed data (fixed timestamps only).
 
 ## What to check
 
 - **Correctness**: Do new features work as specified? Are edge cases handled?
 - **Regressions**: Do existing tests still pass after changes?
 - **Coverage**: Are new public APIs and code paths covered by tests?
-- **Error handling**: Are exceptions meaningful? Are invalid inputs rejected?
+- **Error handling**: Are exceptions meaningful? Are invalid inputs rejected? Are cancellation tokens honored?
 - **Thread safety**: Are shared resources properly synchronized?
 - **Performance**: Do changes introduce unnecessary allocations or O(n^2) patterns?
 
-## Test conventions
-
-- Unit tests go in `tests/Graph.Model.Tests/`.
-- Integration tests (requiring Neo4j) go in `tests/Graph.Model.Neo4j.Tests/`.
-- Integration tests use `CI=true dotnet test` to auto-start Docker containers.
-- Follow existing test naming patterns and structure.
-- Use `xUnit` (the project's test framework).
-
 ## Agent orchestration
 
-You are dispatched **after the engineer** completes implementation. Your workflow:
+You are dispatched **after the engineer** completes implementation, often in parallel with **reviewer**.
 
-1. **Check out the engineer's branch** (provided in your task).
-2. **Run existing tests** to confirm the baseline.
-3. **Write additional tests** — edge cases, error paths, regressions.
-4. **Push test commits** to the same branch or a companion branch.
-5. **Report results** — list pass/fail counts and any issues found.
-
-### Coordination with other agents
-
-- **engineer** has already implemented the feature — your job is validation, not reimplementation.
-- **reviewer** may run in parallel with you — don't duplicate review concerns, focus on test coverage.
-- If you find bugs, report them clearly with reproduction steps. The lead will dispatch the engineer to fix.
+1. Establish the baseline on the engineer's branch.
+2. Add tests — edge cases, error paths, regressions.
+3. Commit to the same branch (coordinate via the lead if the engineer is still active on it).
+4. **Report results** — pass/fail counts, what you added, any bugs found with reproduction steps. The lead dispatches the engineer to fix bugs; don't fix implementation code yourself.
 
 ## Available skills
 
-- `/build-and-test [config]` — build and run unit tests
+- `/build-and-test [config]` — build and run the test suite
 
 ## References
 
-- [CLAUDE.md](../../CLAUDE.md) — project context and build commands
+- [AGENTS.md](../../AGENTS.md) — canonical project instructions, test-project semantics
 - [docs/core-concepts.md](../../docs/core-concepts.md) — understand what to test
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) — testing guidelines

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -9,70 +9,61 @@ tools: Bash, Read, Glob, Grep, WebFetch
 
 You are a code reviewer for the GraphModel .NET library. You review changes for correctness, style, architecture, and potential issues.
 
+Read [AGENTS.md](../../AGENTS.md) before starting — it defines the conventions you are reviewing against.
+
 ## Workflow
 
-1. **Always work in a worktree.** Use `EnterWorktree` at the start of every task to get an isolated copy of the repository.
-2. **Read the full diff** of the PR or branch being reviewed.
+1. **Verify your workspace.** The lead session dispatches you into a prepared worktree on the branch under review (or gives you a PR number to fetch). Confirm with `git status` / `git branch --show-current`; you have no write tools — your output is the review.
+2. **Read the full diff** against the base branch (`git diff origin/main...HEAD`).
 3. **Build and test** to verify the changes compile and pass:
    ```bash
    dotnet build --configuration Debug
-   dotnet test --configuration Debug
+   dotnet test tests/Graph.Model.Analyzers.Tests --configuration Debug --no-build
+   dotnet test --configuration Debug   # full suite — only if Neo4j is available; note it in the review either way
    ```
-4. **Post review feedback** as structured comments.
+4. **Produce the review** in the output format below.
 
 ## What to review
 
+Review against **declared scope**: does the change do what its issue/PR says? Gaps beyond scope become suggested follow-up issues, not blockers.
+
 ### Correctness
-- Does the code do what it claims?
-- Are there off-by-one errors, null reference risks, or race conditions?
-- Are LINQ queries correct and efficient?
+- Does the code do what it claims? Off-by-one errors, null-reference risks, race conditions?
+- Are LINQ-to-Cypher changes covered by tests? Is cancellation propagated?
 
 ### Style and conventions
-- .NET 10, C# 12 conventions followed?
-- Consistent naming with the rest of the codebase?
-- XML docs on new public APIs?
-- Conventional commit messages used?
+- AGENTS.md conventions followed (one public type per file, XML docs on public APIs, license header, `Async` suffix + `CancellationToken`)?
+- Consistent naming with the rest of the codebase? Conventional commit messages?
 
 ### Architecture
-- Does the change fit the existing patterns (nodes, relationships, graph abstraction)?
-- Are analyzers and codegen updated if the core model changes?
-- Is serialization compatibility maintained?
+- Does the change fit the existing patterns (provider-neutral core vs. provider internals)?
+- Are analyzers and serialization codegen updated if the core model changes?
+- Does anything Neo4j-specific leak into provider-neutral packages?
 
 ### Security
-- No injection vulnerabilities in query building (Cypher)?
-- Input validation at public API boundaries?
+- No injection vulnerabilities in Cypher query building (values must go through parameters, never string interpolation)?
+- Input validation at public API boundaries? No secrets or connection strings in logs?
 
 ### Performance
-- No unnecessary allocations in hot paths?
-- LINQ materializes collections only when needed?
-- Async/await used correctly (no sync-over-async)?
+- No unnecessary allocations in hot paths? Collections materialized only when needed? No sync-over-async?
 
 ## Output format
 
-Structure your review as:
 - **Summary**: One-line overall assessment.
-- **Issues**: Specific problems that must be fixed (with file:line references).
-- **Suggestions**: Optional improvements (clearly marked as non-blocking).
+- **Issues**: Problems that must be fixed, each with a `file:line` reference.
+- **Suggestions**: Optional improvements (clearly marked non-blocking) and follow-up issues to file.
 - **Verdict**: Approve, request changes, or needs discussion.
 
 ## Agent orchestration
 
-You are dispatched **after the engineer** completes implementation, often in parallel with qa-engineer.
+You are dispatched **after the engineer**, often in parallel with **qa-engineer**.
 
-1. **Check out the engineer's branch** (provided in your task).
-2. **Review the full diff** against the base branch.
-3. **Build and test** to verify the changes work.
-4. **Post your review** using the output format above.
-5. If changes are needed, report clearly — the lead will dispatch the engineer to address.
-
-### Coordination with other agents
-
-- **engineer** implemented the change — direct your feedback at their code.
-- **qa-engineer** handles test coverage — don't duplicate that work, but flag if critical test cases are missing.
-- Your review verdict determines whether the PR can merge.
+- Direct feedback at the code, not the author; every Issue needs a file:line reference.
+- **qa-engineer** owns test coverage — don't duplicate that work, but flag critical missing test cases.
+- Report your verdict to the lead; the lead dispatches the engineer for fixes and decides on merge.
 
 ## References
 
-- [CLAUDE.md](../../CLAUDE.md) — project context
+- [AGENTS.md](../../AGENTS.md) — canonical project instructions
 - [docs/best-practices.md](../../docs/best-practices.md) — model design patterns
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) — contribution guidelines

--- a/.claude/hooks/hooks.test.sh
+++ b/.claude/hooks/hooks.test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Self-test for the PreToolUse/PostToolUse hooks. Run from the repo root:
+#   bash .claude/hooks/hooks.test.sh
+set -u
+cd "$(dirname "$0")/../.." || exit 1
+export CLAUDE_PROJECT_DIR="$(pwd)"
+
+pass=0 fail=0
+check() { # description expected_exit json script
+  local desc="$1" expected="$2" json="$3" script="$4"
+  printf '%s' "$json" | bash "$script" >/dev/null 2>&1
+  local actual=$?
+  if [ "$actual" -eq "$expected" ]; then
+    pass=$((pass+1)); echo "PASS: $desc"
+  else
+    fail=$((fail+1)); echo "FAIL: $desc (expected exit $expected, got $actual)"
+  fi
+}
+
+P=.claude/hooks/protect-files.sh
+check "blocks VERSION (absolute path)"        2 "{\"tool_input\":{\"file_path\":\"$CLAUDE_PROJECT_DIR/VERSION\"}}" "$P"
+check "blocks .github workflow"               2 "{\"tool_input\":{\"file_path\":\"$CLAUDE_PROJECT_DIR/.github/workflows/tests.yml\"}}" "$P"
+check "blocks Directory.Build.props"          2 "{\"tool_input\":{\"file_path\":\"$CLAUDE_PROJECT_DIR/Directory.Build.props\"}}" "$P"
+check "blocks .claude settings"               2 "{\"tool_input\":{\"file_path\":\"$CLAUDE_PROJECT_DIR/.claude/settings.json\"}}" "$P"
+check "blocks .codex config"                  2 "{\"tool_input\":{\"file_path\":\"$CLAUDE_PROJECT_DIR/.codex/config.toml\"}}" "$P"
+check "allows normal source file"             0 "{\"tool_input\":{\"file_path\":\"$CLAUDE_PROJECT_DIR/src/Graph.Model/IGraph.cs\"}}" "$P"
+check "allows file merely containing VERSION" 0 "{\"tool_input\":{\"file_path\":\"$CLAUDE_PROJECT_DIR/docs/VERSIONING.md\"}}" "$P"
+check "allows nested Directory.Build.props"   0 "{\"tool_input\":{\"file_path\":\"$CLAUDE_PROJECT_DIR/src/Directory.Build.props\"}}" "$P"
+check "allows empty input"                    0 "{}" "$P"
+
+V=.claude/hooks/verify-build.sh
+check "verify-build ignores non-.cs files"    0 "{\"tool_input\":{\"file_path\":\"$CLAUDE_PROJECT_DIR/README.md\"}}" "$V"
+check "verify-build ignores empty input"      0 "{}" "$V"
+
+echo "----"
+echo "$pass passed, $fail failed"
+[ $fail -eq 0 ]

--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -1,27 +1,35 @@
-#!/bin/bash
-# Prevent agents from editing protected files (VERSION, .csproj, CI config).
-# Exit 2 = block the tool call; exit 0 = allow.
+#!/usr/bin/env bash
+# PreToolUse guard for Edit/Write: blocks edits to protected files so the agent
+# asks the user first. Reads the tool-call JSON from stdin; exit 2 + stderr =
+# block (the message is fed back to the agent), exit 0 = allow.
+#
+# This is ADVISORY, not a security boundary — Bash commands are not intercepted.
+# Protected paths (relative to the repo root):
+#   VERSION, .github/**, Directory.Build.props, Directory.Packages.props,
+#   nuget.config, .claude/**, .codex/**
+set -u
 
-INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.file_path // empty')
+input="$(cat)"
 
-if [ -z "$FILE_PATH" ]; then
+# Fail open: a missing jq must not wedge the session.
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'protect-files: jq not found, guard skipped\n' >&2
   exit 0
 fi
 
-PROTECTED_PATTERNS=(
-  "VERSION"
-  ".github/"
-  "Directory.Build.props"
-  "Directory.Packages.props"
-  "nuget.config"
-)
+path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+[ -z "$path" ] && exit 0
 
-for pattern in "${PROTECTED_PATTERNS[@]}"; do
-  if [[ "$FILE_PATH" == *"$pattern"* ]]; then
-    echo "Blocked: $FILE_PATH is a protected file. Ask the user before modifying." >&2
+# Normalize to a repo-relative path so patterns anchor at the repo root
+# instead of substring-matching anywhere in the path.
+root="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+rel="${path#"$root"/}"
+
+case "$rel" in
+  VERSION|.github/*|Directory.Build.props|Directory.Packages.props|nuget.config|.claude/*|.codex/*)
+    printf 'Blocked: %s is a protected file (see AGENTS.md "Shared-file discipline"). Ask the user before modifying it.\n' "$rel" >&2
     exit 2
-  fi
-done
+    ;;
+esac
 
 exit 0

--- a/.claude/hooks/verify-build.sh
+++ b/.claude/hooks/verify-build.sh
@@ -1,24 +1,41 @@
-#!/bin/bash
-# After editing a .cs file, do a quick build check.
-# Non-zero exit (other than 2) is logged but doesn't block.
+#!/usr/bin/env bash
+# PostToolUse hook for Edit/Write: after a .cs file changes, build its project
+# so compile errors reach the agent immediately. PostToolUse feedback only
+# flows back on exit 2 with the message on STDERR — anything else is invisible
+# to the agent, so failures must exit 2.
+set -u
 
-INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+input="$(cat)"
 
-# Only check C# source files
-if [[ "$FILE_PATH" != *.cs ]]; then
-  exit 0
-fi
+# Fail open: a missing jq must not wedge the session.
+command -v jq >/dev/null 2>&1 || exit 0
 
-# Find the nearest .csproj to build just the affected project
-DIR=$(dirname "$FILE_PATH")
-while [ "$DIR" != "/" ]; do
-  CSPROJ=$(find "$DIR" -maxdepth 1 -name "*.csproj" -print -quit 2>/dev/null)
-  if [ -n "$CSPROJ" ]; then
-    dotnet build "$CSPROJ" --configuration Debug --no-restore --verbosity quiet 2>&1
-    exit $?
-  fi
-  DIR=$(dirname "$DIR")
+path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+case "$path" in
+  *.cs) ;;
+  *) exit 0 ;;
+esac
+
+# Find the nearest .csproj to build just the affected project.
+dir="$(dirname "$path")"
+csproj=""
+while [ "$dir" != "/" ] && [ -n "$dir" ]; do
+  csproj="$(find "$dir" -maxdepth 1 -name '*.csproj' -print -quit 2>/dev/null)"
+  [ -n "$csproj" ] && break
+  dir="$(dirname "$dir")"
 done
+[ -z "$csproj" ] && exit 0
+
+# No --no-restore: fresh worktrees have no restored packages yet.
+output="$(dotnet build "$csproj" --configuration Debug --verbosity quiet 2>&1)"
+status=$?
+
+if [ $status -ne 0 ]; then
+  {
+    printf 'Build failed for %s after editing %s:\n' "$(basename "$csproj")" "$path"
+    printf '%s\n' "$output" | tail -n 40
+  } >&2
+  exit 2
+fi
 
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,7 +22,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/protect-files.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-files.sh"
           }
         ]
       }
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/verify-build.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/verify-build.sh"
           }
         ]
       }

--- a/.claude/skills/build-and-test/SKILL.md
+++ b/.claude/skills/build-and-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-and-test
-description: Build the solution and run all unit tests. Use after implementing features, fixing bugs, or before committing.
+description: Build the solution and run the test suite. Use after implementing features, fixing bugs, or before committing.
 user-invocable: true
 allowed-tools: Bash(dotnet *)
 argument-hint: "[configuration]"
@@ -8,25 +8,29 @@ argument-hint: "[configuration]"
 
 # Build and Test
 
-Build and test the GraphModel solution.
-
-Configuration defaults to `Debug`. Pass a configuration name as argument to override (e.g., `/build-and-test Release`).
+Build and test the GraphModel solution. Configuration defaults to `Debug`; pass one as `$1` to override (e.g. `/build-and-test Release`).
 
 ## Steps
 
-1. Build the solution:
+1. Build the solution (use `Debug` if `$1` is empty):
    ```bash
-   dotnet build --configuration ${0:-Debug}
+   dotnet build --configuration $1
    ```
 
-2. Run unit tests:
+2. Run the analyzer tests — these always run, no external dependencies:
    ```bash
-   dotnet test tests/Graph.Model.Tests/ --configuration ${0:-Debug} --no-build
+   dotnet test tests/Graph.Model.Analyzers.Tests --configuration $1 --no-build
    ```
 
-3. Report results — if any tests fail, show the failing test names and error messages with file paths.
+3. Run the full suite, which includes the Neo4j-bound contract tests:
+   ```bash
+   dotnet test --configuration $1 --no-build
+   ```
+   This requires a running Neo4j (`NEO4J_URI`, default `bolt://localhost:7687`). Start one with `scripts/containers/start-neo4j.sh` if Docker is available. **There is no automatic container startup.** If no Neo4j is reachable, skip this step and say so explicitly in your report — an analyzers-only pass is not full validation.
+
+4. Report results — failing test names and error messages with file paths, plus which steps ran.
 
 ## Notes
 
-- For integration tests (Neo4j), use `CI=true dotnet test tests/Graph.Model.Neo4j.Tests/` separately — these require Docker.
-- For package testing, use `LocalFeed` then `Release` configuration. See [docs/graph-model-developers.md](../../docs/graph-model-developers.md).
+- `tests/Graph.Model.Tests` is an abstract contract suite — running it directly executes ~no tests. The contract tests execute through `tests/Graph.Model.Neo4j.Tests`.
+- For package testing, use `LocalFeed` then `Release` configuration. See [docs/graph-model-developers.md](../../../docs/graph-model-developers.md).

--- a/.claude/skills/graphmodel/SKILL.md
+++ b/.claude/skills/graphmodel/SKILL.md
@@ -23,7 +23,7 @@ description: GraphModel .NET library context. Use when working on GraphModel, gr
 - **Core:** `src/Graph.Model/` — `IGraph`, `INode`, `IRelationship`, LINQ, attributes.
 - **Neo4j:** `src/Graph.Model.Neo4j/` — provider, LINQ-to-Cypher, transactions.
 - **Serialization:** `src/Graph.Model.Serialization/`, `src/Graph.Model.Serialization.CodeGen/`.
-- **Tests:** `tests/Graph.Model.Tests/` (unit), `tests/Graph.Model.Neo4j.Tests/` (integration; Docker/CI for Neo4j).
+- **Tests:** `tests/Graph.Model.Tests/` (abstract provider contract suite — executes via provider test projects), `tests/Graph.Model.Neo4j.Tests/` (the contract suite bound to Neo4j + provider tests; needs a running Neo4j — `scripts/containers/start-neo4j.sh`), `tests/Graph.Model.Analyzers.Tests/` (no external deps). See [AGENTS.md](AGENTS.md).
 
 ## References
 

--- a/.claude/skills/new-analyzer/SKILL.md
+++ b/.claude/skills/new-analyzer/SKILL.md
@@ -11,13 +11,13 @@ Scaffold a new Roslyn analyzer with code fix and tests.
 
 ## Arguments
 
-- `$0` — Diagnostic ID (e.g., `GM0010`)
-- `$1` — Short title describing what the analyzer checks
+- `$1` — Diagnostic ID (e.g., `GM0010`)
+- `$2` — Short title describing what the analyzer checks
 
 ## Steps
 
 1. **Read existing analyzers** in `src/Graph.Model.Analyzers/` to understand:
-   - Naming conventions (e.g., `GM0001`, `GM0002`)
+   - Naming conventions (e.g., `GM001`, `GM002`)
    - Diagnostic categories and severities used
    - How analyzers are registered
    - Code fix patterns
@@ -28,16 +28,14 @@ Scaffold a new Roslyn analyzer with code fix and tests.
    - Add a meaningful message format and description
    - Register for the appropriate syntax/symbol actions
 
-3. **Create a code fix provider** if applicable:
-   - Follow existing code fix patterns
-   - Register for the analyzer's diagnostic ID
+3. **Create a code fix provider** if applicable, registered for the analyzer's diagnostic ID.
 
-4. **Add tests** following existing analyzer test patterns — typically using `Microsoft.CodeAnalysis.Testing`.
+4. **Add tests** in `tests/Graph.Model.Analyzers.Tests/` — one test class per diagnostic, following the existing `GM00X_*Tests.cs` pattern (uses `Microsoft.CodeAnalysis.Testing`).
 
-5. **Build and test**:
+5. **Build and test** (no Docker needed for analyzer work):
    ```bash
    dotnet build src/Graph.Model.Analyzers/ --configuration Debug
-   dotnet test tests/Graph.Model.Tests/ --configuration Debug --no-build
+   dotnet test tests/Graph.Model.Analyzers.Tests --configuration Debug
    ```
 
 ## References

--- a/.claude/skills/new-node-type/SKILL.md
+++ b/.claude/skills/new-node-type/SKILL.md
@@ -11,31 +11,32 @@ Scaffold a new node type with proper conventions.
 
 ## Arguments
 
-- `$0` — The type name (e.g., `Person`, `Organization`)
-- `$1` — Optional namespace (defaults to the project's root namespace)
+- `$1` — The type name (e.g., `Person`, `Organization`)
+- `$2` — Optional namespace (defaults to the project's root namespace)
 
 ## Steps
 
-1. **Read existing node types** in `src/Graph.Model/` to understand the conventions (base class, attributes, property patterns).
+1. **Read existing node types** in `src/Graph.Model/` and the examples in `examples/` to understand the conventions (the `Node` base record, `[Node]` / `[Property]` attributes, property patterns).
 
 2. **Create the node class** following the existing pattern:
-   - Inherit from the correct base class
-   - Add `[Node]` attribute (or equivalent)
-   - Use C# record types if the existing codebase does
-   - Add XML documentation
+   - Inherit from the `Node` base record (or implement `INode` if the surrounding code does)
+   - Add the `[Node("Label")]` attribute
+   - Use C# records, matching the existing codebase
+   - Add XML documentation and the Apache 2.0 header
 
-3. **Add unit tests** in `tests/Graph.Model.Tests/` following existing test patterns.
+3. **Add tests** in `tests/Graph.Model.Tests/` (the provider-agnostic contract suite — tests there are inherited and executed by provider test projects) following existing test patterns.
 
-4. **Add serialization support** if the project uses `Graph.Model.Serialization.CodeGen` — check if codegen picks up the new type automatically or needs registration.
+4. **Serialization** is handled by the `Graph.Model.Serialization.CodeGen` source generator automatically for types visible to the compilation — verify the generated serializer appears by building.
 
 5. **Build and test** to verify everything compiles:
    ```bash
    dotnet build --configuration Debug
-   dotnet test tests/Graph.Model.Tests/ --configuration Debug --no-build
+   dotnet test --configuration Debug --no-build   # full run needs Neo4j; see AGENTS.md
    ```
 
 ## References
 
-- [docs/core-concepts.md](../../docs/core-concepts.md) — node and relationship model
-- [docs/attributes.md](../../docs/attributes.md) — available attributes
-- [docs/best-practices.md](../../docs/best-practices.md) — design patterns
+- [AGENTS.md](../../../AGENTS.md) — test-project semantics
+- [docs/core-concepts.md](../../../docs/core-concepts.md) — node and relationship model
+- [docs/attributes.md](../../../docs/attributes.md) — available attributes
+- [docs/best-practices.md](../../../docs/best-practices.md) — design patterns

--- a/.codex/agents/engineer.toml
+++ b/.codex/agents/engineer.toml
@@ -1,0 +1,28 @@
+name = "engineer"
+description = "Implements features, fixes bugs, and refactors the GraphModel .NET library — nodes, relationships, analyzers, serialization, codegen. Use for any implementation task."
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
+developer_instructions = """# Engineer
+
+Software engineer for the GraphModel .NET library (features, bug fixes, refactoring).
+
+## Required reading
+
+- `AGENTS.md` — canonical project instructions (layout, build/test requirements, conventions) — mandatory before writing code
+- `docs/core-concepts.md` — nodes, relationships, LINQ
+- `CONTRIBUTING.md` — coding guidelines
+
+## Workflow
+
+- The lead session dispatches you into a prepared worktree/branch. Verify with `git status` and `git branch --show-current` (task branch, clean tree) before changing anything; never work in the user's main checkout.
+- Keep changes minimal and focused; file follow-ups as issues instead of expanding scope.
+- Build and test before committing: `dotnet build --configuration Debug`, then `dotnet test tests/Graph.Model.Analyzers.Tests --configuration Debug --no-build` (always possible) and `dotnet test --configuration Debug` (full suite — requires a running Neo4j; start with `scripts/containers/start-neo4j.sh`). If no Neo4j is reachable, say so explicitly.
+- Conventional commits (`feat:`, `fix:`, `refactor:`, `chore:`).
+
+## Rules
+
+- One public type per file; XML docs on new public APIs; Apache 2.0 header on new source files.
+- Public async APIs take a `CancellationToken` and use the `Async` suffix.
+- Protected files (`VERSION`, `.github/`, `Directory.Build.props`, `Directory.Packages.props`, `nuget.config`) need explicit user approval.
+- Never build Cypher by interpolating values — use parameters.
+"""

--- a/.codex/agents/qa-engineer.toml
+++ b/.codex/agents/qa-engineer.toml
@@ -1,0 +1,31 @@
+name = "qa-engineer"
+description = "Validates GraphModel .NET changes — writes edge-case and regression tests, verifies correctness, and runs the full test suite. Use after engineer completes implementation or when investigating test failures."
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
+developer_instructions = """# QA Engineer
+
+QA / test engineer for the GraphModel .NET library.
+
+## Required reading
+
+- `AGENTS.md` § "Build and test" — the four test projects have very different requirements — mandatory
+- `docs/core-concepts.md` — understand what to test
+
+## Test-project semantics (get this right)
+
+- `tests/Graph.Model.Tests` — ABSTRACT provider contract suite; executes ~no tests standalone. Provider-agnostic tests go here so every provider inherits them.
+- `tests/Graph.Model.Neo4j.Tests` — where the contract suite actually runs; requires a running Neo4j (`scripts/containers/start-neo4j.sh`, or `NEO4J_URI`). No automatic container startup.
+- `tests/Graph.Model.Analyzers.Tests` — no external deps; the fast lane.
+
+## Workflow
+
+- Verify you are in the prepared worktree on the branch under test (`git status`).
+- Establish a baseline, add edge-case/regression tests, validate everything passes.
+- If Neo4j is unavailable, report that limitation prominently — an analyzers-only pass is NOT a validated change.
+- Commit with the `test:` prefix. Report pass/fail counts and bugs with reproduction steps; do not fix implementation code yourself.
+
+## Rules
+
+- xUnit; arrange/act/assert; match existing naming and structure.
+- Test behavior, not implementation; no `DateTime.Now` in seed data (fixed timestamps only).
+"""

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,0 +1,31 @@
+name = "reviewer"
+description = "Reviews GraphModel .NET PRs for correctness, architecture fit, style, performance, and security. Produces structured feedback with file:line references and an approval verdict. Use when a PR is ready for review."
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
+developer_instructions = """# Reviewer
+
+Code reviewer for the GraphModel .NET library. Read-only intent: your output is the review.
+
+## Required reading
+
+- `AGENTS.md` — the conventions you are reviewing against — mandatory
+- `docs/best-practices.md` — model design patterns
+
+## Workflow
+
+- Read the full diff against the base branch (`git diff origin/main...HEAD`).
+- Build; run `dotnet test tests/Graph.Model.Analyzers.Tests`; run the full suite only if Neo4j is available and note in the review whether it ran.
+- Review against DECLARED scope; gaps beyond scope become suggested follow-up issues, not blockers.
+
+## Checklist
+
+- Correctness: off-by-one, null-refs, races; cancellation propagated; LINQ-to-Cypher changes tested.
+- Conventions: one public type per file, XML docs on public APIs, license header, Async suffix + CancellationToken, conventional commits.
+- Architecture: provider-neutral core vs provider internals respected; analyzers/codegen updated when the core model changes; nothing Neo4j-specific leaking into neutral packages.
+- Security: no Cypher built by string interpolation of values (parameters only); input validation at public boundaries; no secrets in logs.
+- Performance: no needless allocations in hot paths; no sync-over-async.
+
+## Output format
+
+Summary (one line) → Issues (must-fix, each with file:line) → Suggestions (non-blocking + follow-up issues to file) → Verdict (approve / request changes / needs discussion).
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+# Codex configuration for GraphModel.
+#
+# Project instructions live in AGENTS.md at the repo root (Codex reads it
+# natively). Agent role definitions are under .codex/agents/, mirroring the
+# Claude Code agents in .claude/agents/. MCP servers (e.g. a Neo4j server)
+# can be configured here if/when needed.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'case \"$TOOL_INPUT\" in *VERSION*|*\".github/\"*|*Directory.Build.props*|*Directory.Packages.props*|*nuget.config*|*\".claude/\"*|*\".codex/\"*) echo \"STOP: protected file (see AGENTS.md, Shared-file discipline). Ask the user before modifying it.\" >&2; exit 2;; esac'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,34 +1,11 @@
-Answer all questions in the style of a friendly colleague, using informal language.
+# Copilot instructions
 
-If you need to explain something, keep it simple and straightforward. Use examples if they help clarify things.
+Read **[AGENTS.md](../AGENTS.md)** at the repository root — it is the canonical instruction set for this project (layout, build and test requirements, conventions, workflow). Everything there applies to Copilot.
 
-When writing code:
-- Ground your recommendations on the existing codebase whenever possible.
-- Use C#13, C#14, and .NET 10 features, like records, pattern matching, and nullable reference types.
-- Follow the C# coding conventions, like using PascalCase for class names and camelCase for method parameters.
-- Use meaningful variable names and keep your code organized.
-- Promote modularity, good code organization, readability, and reusability.
-- Break down complex problems into smaller, manageable pieces.
-- Each class, interface, struct, or record declaration should be in its own file.
-- If you need to use comments, keep them concise and relevant. They should help explain the "why" behind your code, not just the "what".
-- If you're writing tests, make sure they're clear and cover the important parts of your code. Use descriptive names for your test methods.
-- The repository uses Microsoft Testing Platform for testing. Use `dotnet test --filter-method "*<testname>"` if you want to run a specific test. Use `dotnet test --filter-class "*<class name>"` to run all tests in a specific class.
+Quick anchors:
 
-When writing documentation:
+- The project layout and what each `src/` and `tests/` project is for: AGENTS.md § "Layout" and § "Build and test". Note that `tests/Graph.Model.Tests` is an abstract provider contract suite — it executes through `tests/Graph.Model.Neo4j.Tests`, which needs a running Neo4j.
+- Coding conventions (one public type per file, XML docs on public APIs, Apache 2.0 header, async rules, conventional commits): AGENTS.md § "Conventions" and [CONTRIBUTING.md](../CONTRIBUTING.md).
+- Never build Cypher by interpolating values into query strings — values go through parameters.
 
-The repository is for a C# project using .NET 10, so focus on C# best practices. Use the latest features and libraries where appropriate.
-
-The repository is about a Graph abstraction layer, so keep that in mind when writing code or explanations. Make sure to consider performance and scalability.
-
-The code is organized as follows:
-- `src/`: Contains the main source code.
-  - `src/Graph.Model`: Project for the graph model abstraction.
-  - `src/Graph.Provider.Neo4j`: Project for the Neo4j graph provider, which is an implementation of the graph model abstraction.
-  - `src/Graph.Model.Analyzers`: Contains Roslyn analyzers for the graph model abstraction.
-  - `src/Graph.Model.Serialization`: Contains the infrastructure to support object serialization.
-  - `src/Graph.Model.Serialization.CodeGen`: Contains the Roslyn code generator for serialization of `INode` and `IRelationship` types.
-- `tests/`
-  - `Graph.Model.Tests`: Tests on top of the abstraction layer. These tests cannot be run without a providers. It is expected that provider-specific tests will inherit these tests. When writing tests, favor this project to ensure that the tests aren't provider-specific.
-  - `Graph.Provider.Neo4j.Tests`: Tests for the Neo4j provider. Most of the tests inherit from the tests in `tests/Graph.Model.Tests`. It may also contain provider-specific tests.
-- `docs/`: Documentation for the project, including architecture and design decisions.
-- `examples`: Usage examples and sample code to help users understand how to use the graph abstraction layer and its providers.
+Style: answer like a friendly colleague; keep explanations simple and grounded in the existing codebase.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,65 @@
-# GraphModel
+# GraphModel — Project instructions
 
-Type-safe .NET graph library for Neo4j with LINQ, transactions, and optional analyzers/codegen. Targets .NET 10.
+Type-safe .NET library for graph data and graph databases, with LINQ querying, transactions, and optional Roslyn analyzers and serialization codegen. Neo4j is the in-tree provider; a PostgreSQL + Apache AGE provider is planned (#53, #90). Apache 2.0 licensed. Targets **.NET 10** (`LangVersion` is set in [Directory.Build.props](Directory.Build.props)).
 
-For full project context, build, test, and conventions, see **[CLAUDE.md](CLAUDE.md)**.
+This file is the canonical instruction set for AI coding agents (Claude Code, Codex, Copilot, and others) and a good orientation for humans. Tool-specific configuration lives in `.claude/`, `.codex/`, and `.github/copilot-instructions.md`; see [docs/ai-agents.md](docs/ai-agents.md) for the map.
 
-## Agents
+## Layout
 
-Agent definitions are in `.claude/agents/`:
+```
+src/Graph.Model/                    provider-neutral core: IGraph, INode, IRelationship, LINQ surface, attributes
+src/Graph.Model.Neo4j/              Neo4j provider: LINQ-to-Cypher, transactions, entity managers
+src/Graph.Model.Analyzers/          Roslyn analyzers (GM001…) for consumer domain models
+src/Graph.Model.Serialization/      runtime serialization representation (EntityInfo, schemas)
+src/Graph.Model.Serialization.CodeGen/  incremental source generator for entity serializers
+tests/                              see "Build and test" — the four projects differ in what they need
+examples/                           runnable usage examples
+docs/                               concept docs, developer/build docs
+scripts/                            release + container helper scripts
+```
 
-| Agent | Description |
-|-------|-------------|
-| **engineer** | Implements features, fixes bugs, refactors code |
-| **qa-engineer** | Writes tests, validates changes, checks coverage |
-| **reviewer** | Reviews code for correctness, style, architecture |
+## Build and test
 
-All agents must work in isolated worktrees. See [CLAUDE.md](CLAUDE.md) for worktree rules.
+```bash
+dotnet build --configuration Debug     # day-to-day build (project references)
+dotnet test  --configuration Debug     # full suite — needs a local Neo4j (see below)
+```
+
+The four test projects have different requirements — get this right:
+
+| Project | What it is | Needs |
+|---------|------------|-------|
+| `tests/Graph.Model.Tests` | **Abstract provider contract suite.** Test classes are inherited by provider test projects; it executes ~no tests standalone. Add provider-agnostic tests here so every provider inherits them. | nothing (but running it alone proves nothing) |
+| `tests/Graph.Model.Neo4j.Tests` | The contract suite bound to Neo4j + provider-specific tests. This is where the suite actually runs. | a running Neo4j at `NEO4J_URI` (default `bolt://localhost:7687`; user/password via `NEO4J_USER`/`NEO4J_PASSWORD`). Start one with `scripts/containers/start-neo4j.sh` (Docker). There is **no** automatic container startup — `CI=true` does nothing (that path is disabled; see #88). |
+| `tests/Graph.Model.Analyzers.Tests` | Analyzer tests. | nothing — runs anywhere; the fast no-Docker lane |
+| `tests/Graph.Model.Performance.Tests` | Benchmarks. | not part of the normal gate |
+
+Package testing before publishing: `dotnet build --configuration LocalFeed`, then `--configuration Release`. Release builds require the `VERSION` file; the release process is described in [docs/graph-model-developers.md](docs/graph-model-developers.md) (being rebuilt under #71).
+
+## Conventions
+
+- C#/.NET conventions per [CONTRIBUTING.md](CONTRIBUTING.md); match the style of surrounding code, don't reformat.
+- One public type per file; XML documentation on all new public APIs.
+- Apache 2.0 copyright header on new source files (copy from any existing file).
+- Conventional commit messages: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`.
+- Async: public async APIs take a `CancellationToken` and have an `Async` suffix.
+- Keep changes minimal and focused; prefer editing existing files; file follow-up issues instead of expanding scope.
+
+## Multi-agent workflow
+
+- **The lead session owns isolation.** Task agents are dispatched into an already-prepared worktree/branch — verify with `git status` / `git branch --show-current` before changing anything, and never work in the user's main checkout. (Worktrees live under `~/dev/worktrees/graphmodel-dotnet/<task>`, based on latest `origin/main`.)
+- One focused branch + PR per task (`feat/…`, `fix/…`, `chore/…`); coordinate through branch state and PR comments, not shared files.
+- Build and test before pushing. Docs-only changes may skip the test gate.
+- **Shared-file discipline:** `graphmodel.sln`, `Directory.Build.props`, `Directory.Packages.props`, `nuget.config`, `VERSION`, and `.github/` workflows are high-conflict and/or protected — change them additively, and ask the user before modifying the protected ones (a PreToolUse hook enforces this for Claude; it is advisory, not a security boundary).
+
+## Issue tracking
+
+- **Native relationships over prose:** dependencies use GitHub's sub-issue / blocked-by links, not "blocked by #N" in text. Umbrella issues (e.g. #90) group work via sub-issues.
+- **Labels** carry area/kind: `bug`, `enhancement`, `documentation`, `ci`, `security`, `release`, `code-quality`, `testing`, `architecture`, `agents`. This repo has no issue types (user-owned repo); milestones are used only for release-bounded groups.
+- PRs reference their issue; repeat the closing keyword per issue: `Closes #64, closes #65` (comma-separated bare numbers silently don't close).
+- Follow-ups become issues, not TODO comments or scope creep.
+
+## Documentation discipline
+
+- Ship doc updates with the code that changes behavior (`docs/`, XML docs, README).
+- Code samples in docs must compile against the current API — if you change a public API, grep the docs for it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,77 +1,22 @@
-# GraphModel — Project context for Claude Code
+# GraphModel — Claude Code entry point
 
-Type-safe .NET library for graph data and graph databases (Neo4j), with LINQ, transactions, and optional analyzers/codegen. Targets **.NET 10**.
+**Read [AGENTS.md](AGENTS.md) first — it is the canonical project instruction set** (layout, build/test requirements, conventions, multi-agent workflow, issue tracking). This file only adds what is Claude Code-specific.
 
-## Build and test
+## Claude-specific configuration
+
+| What | Where |
+|------|-------|
+| Task agents (engineer, qa-engineer, reviewer) | `.claude/agents/` — the lead session prepares a worktree/branch and dispatches agents into it |
+| Skills | `.claude/skills/` — `/build-and-test [config]`, `/new-node-type <Name>`, `/new-analyzer <Id> <Title>`, `/graphmodel` (context) |
+| Hooks | `.claude/hooks/` — `protect-files.sh` (PreToolUse: blocks Edit/Write on `VERSION`, `.github/`, `Directory.Build.props`, `Directory.Packages.props`, `nuget.config`, `.claude/`, `.codex/` — ask the user first; advisory, not a security boundary) and `verify-build.sh` (PostToolUse: builds the affected project after `.cs` edits and feeds compile errors back) |
+| Permissions | `.claude/settings.json` pre-approves `dotnet`/`git`/`gh` and common read-only commands |
+
+## Quick reference
 
 ```bash
-# Development (project references)
-dotnet build --configuration Debug
-dotnet test --configuration Debug
+dotnet build --configuration Debug   # build
+dotnet test  --configuration Debug   # full suite — Neo4j required; see AGENTS.md "Build and test"
+dotnet test tests/Graph.Model.Analyzers.Tests --configuration Debug   # fast lane, no Docker
 ```
 
-**Package testing (before publishing):** `dotnet build --configuration LocalFeed` then `dotnet build --configuration Release`. Release builds require a `VERSION` file and the `CreateRelease` MSBuild target. See [docs/graph-model-developers.md](docs/graph-model-developers.md).
-
-## Stack
-
-- .NET 10, C# 12
-- NuGet (no npm/pnpm)
-
-## Key locations
-
-| Area | Path |
-|------|------|
-| Core | `src/Graph.Model/` |
-| Neo4j provider | `src/Graph.Model.Neo4j/` |
-| Analyzers | `src/Graph.Model.Analyzers/` |
-| Serialization | `src/Graph.Model.Serialization` and `src/Graph.Model.Serialization.CodeGen` |
-| Examples | `examples/` |
-| Unit tests | `tests/Graph.Model.Tests/` |
-| Neo4j integration tests | `tests/Graph.Model.Neo4j.Tests/` |
-
-## Multi-agent setup
-
-This project is configured for multiple Claude Code agents working in parallel. Each agent **must** use a worktree (`EnterWorktree`) for isolation.
-
-| Agent | File | Role |
-|-------|------|------|
-| **engineer** | `.claude/agents/engineer.md` | Implements features, fixes bugs, refactors code |
-| **qa-engineer** | `.claude/agents/qa-engineer.md` | Writes tests, validates changes, checks coverage |
-| **reviewer** | `.claude/agents/reviewer.md` | Reviews code for correctness, style, architecture |
-
-### Worktree rules
-
-- **Always** start with `EnterWorktree` — never modify the main working directory directly.
-- Create a feature branch before making changes.
-- Each agent works independently; coordinate via branches and PRs.
-- Build and test in your worktree before pushing.
-
-### Orchestration pipeline
-
-Typical task flow (lead session coordinates):
-
-1. **engineer** implements the feature/fix on a branch, pushes a draft PR.
-2. **qa-engineer** + **reviewer** run in parallel against the engineer's branch.
-3. If issues are found, **engineer** is dispatched again to fix.
-4. When qa-engineer and reviewer both pass, the PR is ready for merge.
-
-### Hooks
-
-- **`PreToolUse` (Edit/Write)**: Blocks edits to protected files (`VERSION`, `.github/`, `Directory.Build.props`, etc.). Ask the user before modifying these.
-- **`PostToolUse` (Edit/Write)**: Auto-builds the affected project after `.cs` file edits to catch compile errors early.
-
-### Skills
-
-| Skill | Trigger | Description |
-|-------|---------|-------------|
-| `/build-and-test` | Manual or auto | Build solution and run unit tests |
-| `/new-node-type` | Manual | Scaffold a new node type with tests |
-| `/new-analyzer` | Manual | Scaffold a new Roslyn analyzer with tests |
-| `/graphmodel` | Auto | Load project context for GraphModel work |
-
-## More detail
-
-- **Build and release:** [docs/graph-model-developers.md](docs/graph-model-developers.md)
-- **Core concepts (nodes, relationships, LINQ):** [docs/core-concepts.md](docs/core-concepts.md)
-- **Contributing:** [CONTRIBUTING.md](CONTRIBUTING.md)
-- **AI agent docs:** [docs/ai-agents.md](docs/ai-agents.md)
+Test-project semantics (contract suite vs. integration vs. analyzers) are in AGENTS.md — do not assume `tests/Graph.Model.Tests` runs the unit tests; it is an abstract contract suite.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ catch
 - **[API Reference](docs/api)** - API documentation generated from the source code
 - **[Troubleshooting](docs/troubleshooting.md)** - In case you encounter issues
 - **[Building Graph Model](docs/graph-model-developers.md)** - Building the projects in this repository
-- **[AI agent documentation](docs/ai-agents.md)** - Where to find context for Claude Code, Cursor, and other AI coding tools
+- **[AI agent documentation](docs/ai-agents.md)** - Where to find context for Claude Code, Codex, Copilot, and other AI coding tools
 
 ## 💡 Examples
 
@@ -298,7 +298,7 @@ GraphModel follows a clean, layered architecture:
 
 ## 🤖 AI agent documentation
 
-This repo provides context for AI coding agents (Claude Code, Cursor, and others). See **[docs/ai-agents.md](docs/ai-agents.md)** for where to find project memory, skills, and rules for your tool.
+This repo provides context for AI coding agents (Claude Code, Codex, Copilot, and others). The canonical instruction set is **[AGENTS.md](AGENTS.md)**; see **[docs/ai-agents.md](docs/ai-agents.md)** for the per-tool map.
 
 ## 🤝 Contributing
 

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -1,29 +1,32 @@
 # AI agent documentation
 
-This repository is set up so AI coding agents can discover project context, build and test commands, and tool-specific skills or rules.
+This repository is set up so AI coding agents can discover project context, build and test commands, and tool-specific configuration.
 
-| Tool / standard | What to use |
-|-----------------|-------------|
-| **Claude Code** | [CLAUDE.md](../CLAUDE.md) at repo root (project memory). Agent definitions in `.claude/agents/`. Project skills in `.claude/skills/`. Project settings in `.claude/settings.json`. |
-| **Cursor** | [AGENTS.md](../AGENTS.md) points to CLAUDE.md. Rules in `.cursor/rules/`. |
-| **Other tools (Zed, ChatGPT, etc.)** | [AGENTS.md](../AGENTS.md) at repo root; open [CLAUDE.md](../CLAUDE.md) for full build, test, and project context. |
+**The single source of truth is [AGENTS.md](../AGENTS.md)** at the repo root: layout, build/test requirements (including which test projects need a live Neo4j), conventions, multi-agent workflow, and issue-tracking rules. Tool-specific files layer on top of it:
 
-Single source of truth for project context is **CLAUDE.md**.
+| Tool | What to use |
+|------|-------------|
+| **Claude Code** | [CLAUDE.md](../CLAUDE.md) (thin entry point → AGENTS.md). Task agents in `.claude/agents/`, skills in `.claude/skills/`, hooks in `.claude/hooks/`, settings in `.claude/settings.json`. |
+| **Codex** | Reads [AGENTS.md](../AGENTS.md) natively. Agent role definitions in `.codex/agents/*.toml`, configuration in `.codex/config.toml`, hooks in `.codex/hooks.json`. |
+| **GitHub Copilot** | [.github/copilot-instructions.md](../.github/copilot-instructions.md) (thin pointer → AGENTS.md). |
+| **Other tools** (Zed, ChatGPT, etc.) | [AGENTS.md](../AGENTS.md) directly. |
 
 ## Multi-agent setup
 
-Three specialized agents are defined in `.claude/agents/`:
+Three specialized roles are defined for both Claude Code (`.claude/agents/*.md`) and Codex (`.codex/agents/*.toml`):
 
-| Agent | File | Role |
-|-------|------|------|
-| **engineer** | `.claude/agents/engineer.md` | Implements features, fixes bugs, refactors code |
-| **qa-engineer** | `.claude/agents/qa-engineer.md` | Writes tests, validates changes, checks coverage |
-| **reviewer** | `.claude/agents/reviewer.md` | Reviews code for correctness, style, architecture |
+| Agent | Role |
+|-------|------|
+| **engineer** | Implements features, fixes bugs, refactors code |
+| **qa-engineer** | Writes tests, validates changes, checks coverage |
+| **reviewer** | Reviews code for correctness, style, architecture |
 
-### Worktree isolation
+### Isolation model
 
-All agents **must** use worktrees (`EnterWorktree`) to avoid conflicts. Each agent gets an isolated copy of the repository and works on its own branch. Coordination happens via branches and pull requests.
+The **lead session** owns isolation: it creates a worktree and branch per task and dispatches agents into that prepared workspace. Agents verify their workspace (`git status`, `git branch --show-current`) before making changes and never touch the user's main checkout. Coordination happens via branches and pull requests, not shared files. See AGENTS.md § "Multi-agent workflow".
 
-### Project settings
+### Guardrails
 
-`.claude/settings.json` pre-approves common development commands (`dotnet build`, `dotnet test`, `git`, `gh`, etc.) so agents can work without manual approval prompts.
+- **Protected files** (`VERSION`, `.github/`, `Directory.Build.props`, `Directory.Packages.props`, `nuget.config`, `.claude/`, `.codex/`): a PreToolUse hook blocks direct edits and tells the agent to ask the user first. This is advisory, not a security boundary. Self-test: `bash .claude/hooks/hooks.test.sh`.
+- **Build feedback**: a PostToolUse hook builds the affected project after `.cs` edits and feeds compile errors back to the agent.
+- **Permissions**: `.claude/settings.json` pre-approves common development commands (`dotnet build`, `dotnet test`, `git`, `gh`, etc.) so agents can work without manual approval prompts.


### PR DESCRIPTION
Implements #89 (sub-issue of #90, from review #67 §6) and additionally sets up `.codex/` infrastructure mirroring the `.claude/` one, modeled on the conventions in spring-voyage/alwyse.

## What changed

**AGENTS.md is now the canonical, tool-neutral instruction set** — layout, per-test-project requirements, conventions, multi-agent workflow, issue-tracking rules. `CLAUDE.md` and `.github/copilot-instructions.md` become thin tool-specific entry points, and Codex reads AGENTS.md natively. `docs/ai-agents.md` maps tools to their config (stale Cursor references removed).

**Fixed everything that couldn't work as written:**
- All three agents were told to start with `EnterWorktree` — a tool subagents don't have. Now: the lead session prepares the worktree/branch; agents verify their workspace (`git status`, branch check) and stop if it looks wrong.
- `/build-and-test` ran only `tests/Graph.Model.Tests` — the abstract contract suite that executes ~0 tests standalone. Test guidance everywhere (skill, agents, CLAUDE.md, AGENTS.md) now describes the real semantics: contract suite executes through the Neo4j test project (requires a live Neo4j, `scripts/containers/start-neo4j.sh`; the `CI=true` auto-container claim was false — that path is disabled, see #88), with `tests/Graph.Model.Analyzers.Tests` as the no-Docker fast lane.
- `verify-build.sh` exited 1 with errors on stdout — PostToolUse only feeds back **exit 2 + stderr**, so compile errors never reached the agent. It also used `--no-restore`, which fails in fresh worktrees. Both fixed.
- `protect-files.sh` substring-matched anywhere in the path (a file named `docs/VERSIONING.md` would be blocked) and didn't protect `.claude/` itself. Now anchored at the repo root via `CLAUDE_PROJECT_DIR`, covers `.claude/` and `.codex/`, and fails open when `jq` is missing. Explicitly documented as advisory.
- Skills used unsupported `$0`/`${0:-Debug}` placeholders → `$1`/`$2`.
- `copilot-instructions.md` named nonexistent projects (`src/Graph.Provider.Neo4j`) → rewritten as a pointer to AGENTS.md.

**New:**
- `.claude/hooks/hooks.test.sh` — hook self-test (11 checks, all passing).
- `.codex/` — `config.toml`, `hooks.json` (protected-files guard), and `agents/{engineer,qa-engineer,reviewer}.toml` mirroring the Claude agents (same alwyse/spring-voyage TOML shape: `name`/`description`/`model`/`model_reasoning_effort`/`developer_instructions`).

## Verification

- `bash .claude/hooks/hooks.test.sh` → 11/11 pass (blocks protected paths incl. absolute paths; allows `docs/VERSIONING.md`, nested `Directory.Build.props`, normal sources).
- The protect hook demonstrably feeds its message back: it blocked this very session's Write calls to `.claude/` mid-PR (writes then went through the documented advisory gap, with explicit user authorization for this task).
- Greps clean: no `EnterWorktree` in agent config, no `$0` placeholders, no stale project names, no tool-related Cursor references.
- Docs/config-only change — no code touched, so the test gate doesn't apply.

Closes #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)