### PR TITLE
[codex] Skip full CI for doc-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,56 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      dotnet: ${{ steps.filter.outputs.dotnet }}
+      ci_workflow: ${{ steps.filter.outputs.ci_workflow }}
+      workflow_files: ${{ steps.filter.outputs.workflow_files }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            dotnet:
+              - '**/*.cs'
+              - '**/*.csproj'
+              - '**/*.sln'
+              - '**/*.props'
+              - '**/*.targets'
+              - '**/*.resx'
+              - '**/appsettings*.json'
+              - 'src/Graph.Model.Analyzers/AnalyzerReleases.*.md'
+              - 'scripts/containers/start-neo4j.sh'
+              - 'global.json'
+              - '.config/dotnet-tools.json'
+              - 'VERSION'
+              - 'VERSION.ASSEMBLY'
+            ci_workflow:
+              # Editing ci.yml can alter any required job below, so fan out
+              # the full CI suite on CI workflow changes.
+              - '.github/workflows/ci.yml'
+            workflow_files:
+              # Non-CI workflow edits only need the lightweight YAML guard.
+              - '.github/workflows/**'
+
   workflow-yaml:
     name: Workflow YAML syntax
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.workflow_files == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 2
 
     steps:
@@ -46,6 +87,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.ci_workflow == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 15
 
     steps:
@@ -72,6 +115,8 @@ jobs:
   test-core:
     name: Test Core
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.ci_workflow == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 15
 
     steps:
@@ -101,6 +146,8 @@ jobs:
   test-analyzers:
     name: Test Analyzers
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.ci_workflow == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 15
 
     steps:
@@ -130,6 +177,8 @@ jobs:
   test-neo4j:
     name: Test Neo4j Provider
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.dotnet == 'true' || needs.changes.outputs.ci_workflow == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 20
 
     steps:
@@ -163,6 +212,7 @@ jobs:
     name: Required checks
     runs-on: ubuntu-latest
     needs:
+      - changes
       - workflow-yaml
       - build
       - test-core
@@ -170,27 +220,34 @@ jobs:
       - test-neo4j
     # Always runs - branch protection depends on a single "Required checks"
     # context, so this job must report a status regardless of which
-    # individual jobs above passed, failed, or were cancelled.
+    # individual jobs above passed, failed, were skipped, or were cancelled.
     if: ${{ always() }}
     timeout-minutes: 5
 
     steps:
-      - name: Verify all required jobs passed
+      - name: Verify all required jobs passed or were skipped
         shell: bash
         env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
           WORKFLOW_YAML_RESULT: ${{ needs.workflow-yaml.result }}
           BUILD_RESULT: ${{ needs.build.result }}
           TEST_CORE_RESULT: ${{ needs.test-core.result }}
           TEST_ANALYZERS_RESULT: ${{ needs.test-analyzers.result }}
           TEST_NEO4J_RESULT: ${{ needs.test-neo4j.result }}
         run: |
+          echo "changes=$CHANGES_RESULT"
           echo "workflow-yaml=$WORKFLOW_YAML_RESULT"
           echo "build=$BUILD_RESULT"
           echo "test-core=$TEST_CORE_RESULT"
           echo "test-analyzers=$TEST_ANALYZERS_RESULT"
           echo "test-neo4j=$TEST_NEO4J_RESULT"
 
-          ok() { [[ "$1" == "success" ]]; }
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "::error::changes detection job failed"
+            exit 1
+          fi
+
+          ok() { [[ "$1" == "success" || "$1" == "skipped" ]]; }
 
           ok "$WORKFLOW_YAML_RESULT"   || { echo "::error::workflow-yaml failed"; exit 1; }
           ok "$BUILD_RESULT"           || { echo "::error::build failed"; exit 1; }


### PR DESCRIPTION
## Summary

- Add a `changes` job to classify CI-relevant path changes before running the expensive jobs.
- Gate build, core tests, analyzer tests, and Neo4j provider tests on .NET/build inputs or `ci.yml` changes.
- Keep the single `Required checks` branch-protection context, allowing path-filtered jobs to report `skipped` while still failing on real failures.

## Why

PR #103 only changed docs under `docs/decisions/`, but the existing CI workflow still ran the full build and test suite, including Neo4j. The workflow had no path-level gating, so every pull request paid the full test cost regardless of changed files.

## Impact

Doc-only PRs should now skip the expensive .NET and Neo4j jobs while still producing the required aggregate check. Changes to code, project/build files, test settings, or `.github/workflows/ci.yml` still fan out to the full suite.

## Validation

- `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/ci.yml\"); puts \"ok .github/workflows/ci.yml\""`
- `git diff --check`
- Confirmed PR #103 changed only `docs/decisions/0001-shared-cypher-translation-layer.md` and `docs/decisions/README.md`.