### PR TITLE
[codex] Run CI for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Adds the `merge_group` trigger to the CI workflow so GitHub merge queue commits run the workflow that publishes the required `Required checks` status.

## Why

PRs #103 and #106 were both in the merge queue with `AWAITING_CHECKS`. Their PR-head checks were green, but only CodeQL ran for the queue branches because `.github/workflows/ci.yml` did not include a `merge_group` trigger. Branch rules require the `Required checks` context, which is produced by CI, so the queue could not observe that required status on merge-group commits.

## Validation

- Parsed `.github/workflows/ci.yml` and `.github/workflows/codeql.yml` with Ruby YAML.
- Ran `git diff --check`.

`actionlint` is not installed locally, so GitHub Actions will provide the full workflow validation.
